### PR TITLE
Fix the plugin for the new version of rusherhack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,6 @@ java {
     if (JavaVersion.current() < javaVersion) {
         toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
     }
-    archivesBaseName = project.archives_base_name
 }
 
 processResources {
@@ -87,6 +86,8 @@ processResources {
         expand(plugin_version: project.plugin_version)
     }
 }
+
+
 
 jar {
     manifest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,23 @@
-# Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-#properties
-minecraft_version = 1.20.1
-plugin_version = v0.2
-maven_group = org.example
-archives_base_name = AutoAnvilRename
+# plugin name
+plugin_name = auto-anvil
 
+# plugin version
+plugin_version = 1.0.0
+
+maven_group = org.icetank
+
+# use java 17 for minecraft versions 1.20.4 and older
+# use java 21 for minecraft versions 1.20.5 and newer
+java_version = 17
+
+# minecraft version to compile with
+# other supported versions of the game can be added in rusherhack-plugin.json
+minecraft_version = 1.20.1
+
+# parchment mappings
+minecraft_version_range = 1.20-1.21.1
+
+# fabric loader version
+fabric_loader_version = 0.16.10

--- a/src/main/java/org/icetank/AutoAnvilRenamePlugin.java
+++ b/src/main/java/org/icetank/AutoAnvilRenamePlugin.java
@@ -24,19 +24,8 @@ public class AutoAnvilRenamePlugin extends Plugin {
 	public void onUnload() {
 		this.getLogger().info(this.getName() + " unloaded!");
 	}
-	
-	@Override
 	public String getName() {
 		return "AutoAnvilRenamePlugin";
 	}
-	
-	@Override
-	public String getVersion() {
-		return "v0.1";
-	}
-	
-	@Override
-	public String getDescription() {
-		return "Auto Anvil Rename";
-	}
+
 }


### PR DESCRIPTION
When you add the plugin to the folder, and run it, you get an error saying that the metadata is missing.
![image](https://github.com/user-attachments/assets/1753cd7f-2578-485b-a7f3-f5c5609b5759)
My pull request corrects this by restoring the missing metadata.